### PR TITLE
Add support for default attributes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    heroicons-ruby (1.0.0)
+    heroicons-ruby (2.0.0.pre.beta.1)
       activesupport (>= 6.0)
       nokogiri (>= 1.6)
 

--- a/README.md
+++ b/README.md
@@ -22,12 +22,23 @@ bundle add heroicons-ruby
 <%= heroicon "arrow-right", class: "h-4 w-4", fill: "none" %>
 ```
 
+
+## Configuration
 Valid `variant` values are `%i[mini solid outline]`. The default variant is `solid` however that default can be changed using:
 
 ```ruby
 # config/initializers/heroicons.rb
 Heroicons.configure do |config|
   config.variant = :mini
+end
+```
+
+If you would like to specify default HTML attributes (eg. `class="h-4 w-4"`) for a given `variant`, you can configure that like so:
+
+```ruby
+# config/initializers/heroicons.rb
+Heroicons.configure do |config|
+  config.attributes[:mini] = { class: "h-4 w-4" }
 end
 ```
 

--- a/lib/heroicons/config.rb
+++ b/lib/heroicons/config.rb
@@ -2,10 +2,11 @@
 
 module Heroicons
   class Config
-    attr_accessor :variant
+    attr_accessor :variant, :attributes
 
     def initialize
       @variant = :solid
+      @attributes = Hash.new { |_hash, _key| {} }
     end
   end
 

--- a/lib/heroicons/helper.rb
+++ b/lib/heroicons/helper.rb
@@ -4,8 +4,10 @@ require "action_view/helpers" if defined?(Rails)
 
 module Heroicons
   module Helper
-    def heroicon(name, variant: Heroicons.config.variant, **options)
-      icon = Heroicons::Icon.new(name: name, variant: variant, options: options)
+    def heroicon(name, variant: Heroicons.config.variant, **attributes)
+      icon = Heroicons::Icon.new(name: name,
+                                 variant: variant,
+                                 attributes: Heroicons.config.attributes[variant].merge(attributes))
 
       raw icon.render
     end

--- a/lib/heroicons/icon.rb
+++ b/lib/heroicons/icon.rb
@@ -2,10 +2,10 @@
 
 module Heroicons
   class Icon
-    def initialize(name:, variant:, options: {})
+    def initialize(name:, variant:, attributes: {})
       @name = name
       @variant = variant
-      @options = options
+      @attributes = attributes
     end
 
     def render
@@ -14,7 +14,7 @@ module Heroicons
       doc = Nokogiri::XML::Document.parse(file)
       svg = doc.at_css("svg")
 
-      @options.each do |k, v|
+      @attributes.each do |k, v|
         svg[dasherize(k.to_s)] = v
       end
 

--- a/lib/heroicons/version.rb
+++ b/lib/heroicons/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Heroicons
-  VERSION = "1.0.0"
+  VERSION = "2.0.0-beta.1"
 end

--- a/test/test_heroicons.rb
+++ b/test/test_heroicons.rb
@@ -42,7 +42,7 @@ class TestHeroicons < Minitest::Test
       viewBox: "0 0 50 50"
     }
 
-    icon = Heroicons::Icon.new(name: @icon_name, variant: :mini, options: custom_attributes).render
+    icon = Heroicons::Icon.new(name: @icon_name, variant: :mini, attributes: custom_attributes).render
     doc = Nokogiri::XML(icon)
     svg = doc.at_css("svg")
 
@@ -61,6 +61,16 @@ class TestHeroicons < Minitest::Test
     end
 
     assert_equal :mini, Heroicons.config.variant
+  end
+
+  def test_it_configures_attributes
+    assert_equal({}, Heroicons.config.attributes)
+
+    Heroicons.configure do |config|
+      config.attributes[:solid] = { class: "h-6 w-6" }
+    end
+
+    assert_equal({ solid: { class: "h-6 w-6" } }, Heroicons.config.attributes)
   end
 
   # def test_it_renders_via_helper


### PR DESCRIPTION
You can now configure default attributes on a per `variant` basis.

```ruby
# config/initializers/heroicons.rb
Heroicons.configure do |config|
  config.attributes[:mini] = { class: "h-4 w-4" }
end